### PR TITLE
Update Podcast link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,44 @@
 
 This repo contains presentations, articles, and other resources related to [Modern Testing Principles](https://moderntesting.org/) created by Alan Page and Brent Jensen. It is a collection of resources shared at our [#OneOfTheThree Slack channel](https://oneofthethree.slack.com/) which you can join [by clicking here](https://join.slack.com/t/oneofthethree/shared_invite/enQtMzQ4NDAxNjE1OTg2LTExMzQwMmQ2NTBlYzcwYWI4Mjg3NjhmYThlYjdhZmIzZGNmM2MyMGNhNjExMGIwMmE2ODI2YjZmYzU2MmQ4NGQ).
 
-All material on this site is shared with permission from the creators.  Unless otherwise noted, all content is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
+All material on this site is shared with permission from the creators. Unless otherwise noted, all content is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
 
 ## The Essentials
+
 - [Modern Testing Principles](https://moderntesting.org/)
-- [The AB Testing Podcast](https://www.angryweasel.com/ABTesting/)
+- [The AB Testing Podcast](https://anchor.fm/abtesting)
 
 ## The People
+
 - Read [Alan's](https://angryweasel.com/blog/) and [Brent's](https://testastic.wordpress.com/) blogs
 - Follow [Alan](https://twitter.com/alanpage?lang=en) and [Brent](https://twitter.com/BrentMJensen) on Twitter
 
 ## Resources
-- [Modern testing Course](https://www.ministryoftesting.com/dojo/courses/introduction-to-modern-testing-alan-page) *by Alan Page*
-- [Quality Culture Transition Guide (google doc)](https://docs.google.com/spreadsheets/d/1kan20hYsdbvk7HW4si-X6Ve1fLtCeTI2H_PjiniKsxY/edit?usp=sharing) *by Alan Page*
-- [Modern Testing Mind Map](https://github.com/mwyrodek/ModernTestingMindMap) *by [Maciej Wyrodek](https://github.com/mwyrodek)*
+
+- [Modern testing Course](https://www.ministryoftesting.com/dojo/courses/introduction-to-modern-testing-alan-page) _by Alan Page_
+- [Quality Culture Transition Guide (google doc)](https://docs.google.com/spreadsheets/d/1kan20hYsdbvk7HW4si-X6Ve1fLtCeTI2H_PjiniKsxY/edit?usp=sharing) _by Alan Page_
+- [Modern Testing Mind Map](https://github.com/mwyrodek/ModernTestingMindMap) _by [Maciej Wyrodek](https://github.com/mwyrodek)_
 
 ## Presentations by Alan and Brent
-- [Adventures in Modern Testing](https://www.youtube.com/watch?v=7IAkkpI5YhA) *by Alan Page*
-- [Back and Beyond: A reflection on Modern Testing](https://vimeo.com/372252456)  *by Alan Page*
-- [Ten Reasons You Think Modern Testing Won’t Work for You](https://www.youtube.com/watch?&v=heU3xHqWecE) *by Brent Jensen and Alan Page*
-- [Building a Data-Centric Modern Quality Culture](https://www.youtube.com/watch?v=7Q87RqN_FcM) *by Brent Jensen*
+
+- [Adventures in Modern Testing](https://www.youtube.com/watch?v=7IAkkpI5YhA) _by Alan Page_
+- [Back and Beyond: A reflection on Modern Testing](https://vimeo.com/372252456) _by Alan Page_
+- [Ten Reasons You Think Modern Testing Won’t Work for You](https://www.youtube.com/watch?&v=heU3xHqWecE) _by Brent Jensen and Alan Page_
+- [Building a Data-Centric Modern Quality Culture](https://www.youtube.com/watch?v=7Q87RqN_FcM) _by Brent Jensen_
 
 ## Presentations by One of the Three
-- [Practical Applications of Modern Testing Principles](https://github.com/MelTheTester/practical_application_of_mtp) *by [Melissa Eaden](https://twitter.com/melthetester)*
-- [Modern Testing in Today's World](https://github.com/moderntesting/resources/blob/master/presentations/Modern_Testing_In_Today_World_Final_Version.pptx) *by [Emna Ayadi](https://twitter.com/emna__ayadi)*
-- [Split Teams differently by building CoP](https://speakerdeck.com/eayedi/split-teams-differently-by-building-cop) *by [Emna Ayadi](https://twitter.com/emna__ayadi)*
-- [Experimenting our Way to Team-based Testing](https://www.slideshare.net/ConorFitzgerald8/experimenting-our-way-to-teambased-testing-soft-test-2019-final-version) *by [Conor Fitzgerald](https://twitter.com/conorfi) and [Robert Meaney](https://twitter.com/RobMeaney)*
-- [Modern Testing Meets Reality](https://www.youtube.com/watch?v=bhn3tGP0XFY&t=11m58s) *by [Danny Faught](https://twitter.com/swalchemist)*
-- [Embracing Change: From Tester to Quality Coach](https://noti.st/unremarkableqa/eKU5vW/embracing-change-from-tester-to-quality-coach) *by [Areti Panou](https://twitter.com/unremarkableQA)*
+
+- [Practical Applications of Modern Testing Principles](https://github.com/MelTheTester/practical_application_of_mtp) _by [Melissa Eaden](https://twitter.com/melthetester)_
+- [Modern Testing in Today's World](https://github.com/moderntesting/resources/blob/master/presentations/Modern_Testing_In_Today_World_Final_Version.pptx) _by [Emna Ayadi](https://twitter.com/emna__ayadi)_
+- [Split Teams differently by building CoP](https://speakerdeck.com/eayedi/split-teams-differently-by-building-cop) _by [Emna Ayadi](https://twitter.com/emna__ayadi)_
+- [Experimenting our Way to Team-based Testing](https://www.slideshare.net/ConorFitzgerald8/experimenting-our-way-to-teambased-testing-soft-test-2019-final-version) _by [Conor Fitzgerald](https://twitter.com/conorfi) and [Robert Meaney](https://twitter.com/RobMeaney)_
+- [Modern Testing Meets Reality](https://www.youtube.com/watch?v=bhn3tGP0XFY&t=11m58s) _by [Danny Faught](https://twitter.com/swalchemist)_
+- [Embracing Change: From Tester to Quality Coach](https://noti.st/unremarkableqa/eKU5vW/embracing-change-from-tester-to-quality-coach) _by [Areti Panou](https://twitter.com/unremarkableQA)_
 
 ## Articles
-- [Getting Testing Bottlenecks Out of Your Pipelines](https://devops.com/get-testing-bottlenecks-out-of-your-pipelines/) *by [Lisa Crispin](https://lisacrispin.com/)*
-- [A Collection of Suggestions I Strenuously Resisted](https://unremarkabletester.com/2019/05/08/a-collection-of-suggestions-i-strenuously-resisted/) *by [Areti Panou](https://twitter.com/unremarkableQA)*
+
+- [Getting Testing Bottlenecks Out of Your Pipelines](https://devops.com/get-testing-bottlenecks-out-of-your-pipelines/) _by [Lisa Crispin](https://lisacrispin.com/)_
+- [A Collection of Suggestions I Strenuously Resisted](https://unremarkabletester.com/2019/05/08/a-collection-of-suggestions-i-strenuously-resisted/) _by [Areti Panou](https://twitter.com/unremarkableQA)_
 
 ## Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -4,44 +4,38 @@
 
 This repo contains presentations, articles, and other resources related to [Modern Testing Principles](https://moderntesting.org/) created by Alan Page and Brent Jensen. It is a collection of resources shared at our [#OneOfTheThree Slack channel](https://oneofthethree.slack.com/) which you can join [by clicking here](https://join.slack.com/t/oneofthethree/shared_invite/enQtMzQ4NDAxNjE1OTg2LTExMzQwMmQ2NTBlYzcwYWI4Mjg3NjhmYThlYjdhZmIzZGNmM2MyMGNhNjExMGIwMmE2ODI2YjZmYzU2MmQ4NGQ).
 
-All material on this site is shared with permission from the creators. Unless otherwise noted, all content is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
+All material on this site is shared with permission from the creators.  Unless otherwise noted, all content is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
 
 ## The Essentials
-
 - [Modern Testing Principles](https://moderntesting.org/)
 - [The AB Testing Podcast](https://anchor.fm/abtesting)
 
 ## The People
-
 - Read [Alan's](https://angryweasel.com/blog/) and [Brent's](https://testastic.wordpress.com/) blogs
 - Follow [Alan](https://twitter.com/alanpage?lang=en) and [Brent](https://twitter.com/BrentMJensen) on Twitter
 
 ## Resources
-
-- [Modern testing Course](https://www.ministryoftesting.com/dojo/courses/introduction-to-modern-testing-alan-page) _by Alan Page_
-- [Quality Culture Transition Guide (google doc)](https://docs.google.com/spreadsheets/d/1kan20hYsdbvk7HW4si-X6Ve1fLtCeTI2H_PjiniKsxY/edit?usp=sharing) _by Alan Page_
-- [Modern Testing Mind Map](https://github.com/mwyrodek/ModernTestingMindMap) _by [Maciej Wyrodek](https://github.com/mwyrodek)_
+- [Modern testing Course](https://www.ministryoftesting.com/dojo/courses/introduction-to-modern-testing-alan-page) *by Alan Page*
+- [Quality Culture Transition Guide (google doc)](https://docs.google.com/spreadsheets/d/1kan20hYsdbvk7HW4si-X6Ve1fLtCeTI2H_PjiniKsxY/edit?usp=sharing) *by Alan Page*
+- [Modern Testing Mind Map](https://github.com/mwyrodek/ModernTestingMindMap) *by [Maciej Wyrodek](https://github.com/mwyrodek)*
 
 ## Presentations by Alan and Brent
-
-- [Adventures in Modern Testing](https://www.youtube.com/watch?v=7IAkkpI5YhA) _by Alan Page_
-- [Back and Beyond: A reflection on Modern Testing](https://vimeo.com/372252456) _by Alan Page_
-- [Ten Reasons You Think Modern Testing Won’t Work for You](https://www.youtube.com/watch?&v=heU3xHqWecE) _by Brent Jensen and Alan Page_
-- [Building a Data-Centric Modern Quality Culture](https://www.youtube.com/watch?v=7Q87RqN_FcM) _by Brent Jensen_
+- [Adventures in Modern Testing](https://www.youtube.com/watch?v=7IAkkpI5YhA) *by Alan Page*
+- [Back and Beyond: A reflection on Modern Testing](https://vimeo.com/372252456)  *by Alan Page*
+- [Ten Reasons You Think Modern Testing Won’t Work for You](https://www.youtube.com/watch?&v=heU3xHqWecE) *by Brent Jensen and Alan Page*
+- [Building a Data-Centric Modern Quality Culture](https://www.youtube.com/watch?v=7Q87RqN_FcM) *by Brent Jensen*
 
 ## Presentations by One of the Three
-
-- [Practical Applications of Modern Testing Principles](https://github.com/MelTheTester/practical_application_of_mtp) _by [Melissa Eaden](https://twitter.com/melthetester)_
-- [Modern Testing in Today's World](https://github.com/moderntesting/resources/blob/master/presentations/Modern_Testing_In_Today_World_Final_Version.pptx) _by [Emna Ayadi](https://twitter.com/emna__ayadi)_
-- [Split Teams differently by building CoP](https://speakerdeck.com/eayedi/split-teams-differently-by-building-cop) _by [Emna Ayadi](https://twitter.com/emna__ayadi)_
-- [Experimenting our Way to Team-based Testing](https://www.slideshare.net/ConorFitzgerald8/experimenting-our-way-to-teambased-testing-soft-test-2019-final-version) _by [Conor Fitzgerald](https://twitter.com/conorfi) and [Robert Meaney](https://twitter.com/RobMeaney)_
-- [Modern Testing Meets Reality](https://www.youtube.com/watch?v=bhn3tGP0XFY&t=11m58s) _by [Danny Faught](https://twitter.com/swalchemist)_
-- [Embracing Change: From Tester to Quality Coach](https://noti.st/unremarkableqa/eKU5vW/embracing-change-from-tester-to-quality-coach) _by [Areti Panou](https://twitter.com/unremarkableQA)_
+- [Practical Applications of Modern Testing Principles](https://github.com/MelTheTester/practical_application_of_mtp) *by [Melissa Eaden](https://twitter.com/melthetester)*
+- [Modern Testing in Today's World](https://github.com/moderntesting/resources/blob/master/presentations/Modern_Testing_In_Today_World_Final_Version.pptx) *by [Emna Ayadi](https://twitter.com/emna__ayadi)*
+- [Split Teams differently by building CoP](https://speakerdeck.com/eayedi/split-teams-differently-by-building-cop) *by [Emna Ayadi](https://twitter.com/emna__ayadi)*
+- [Experimenting our Way to Team-based Testing](https://www.slideshare.net/ConorFitzgerald8/experimenting-our-way-to-teambased-testing-soft-test-2019-final-version) *by [Conor Fitzgerald](https://twitter.com/conorfi) and [Robert Meaney](https://twitter.com/RobMeaney)*
+- [Modern Testing Meets Reality](https://www.youtube.com/watch?v=bhn3tGP0XFY&t=11m58s) *by [Danny Faught](https://twitter.com/swalchemist)*
+- [Embracing Change: From Tester to Quality Coach](https://noti.st/unremarkableqa/eKU5vW/embracing-change-from-tester-to-quality-coach) *by [Areti Panou](https://twitter.com/unremarkableQA)*
 
 ## Articles
-
-- [Getting Testing Bottlenecks Out of Your Pipelines](https://devops.com/get-testing-bottlenecks-out-of-your-pipelines/) _by [Lisa Crispin](https://lisacrispin.com/)_
-- [A Collection of Suggestions I Strenuously Resisted](https://unremarkabletester.com/2019/05/08/a-collection-of-suggestions-i-strenuously-resisted/) _by [Areti Panou](https://twitter.com/unremarkableQA)_
+- [Getting Testing Bottlenecks Out of Your Pipelines](https://devops.com/get-testing-bottlenecks-out-of-your-pipelines/) *by [Lisa Crispin](https://lisacrispin.com/)*
+- [A Collection of Suggestions I Strenuously Resisted](https://unremarkabletester.com/2019/05/08/a-collection-of-suggestions-i-strenuously-resisted/) *by [Areti Panou](https://twitter.com/unremarkableQA)*
 
 ## Miscellaneous
 


### PR DESCRIPTION
The podcast link still went to the angryweasel website. This updates it to anchor.fm